### PR TITLE
Fix: scope Health Connect aggregate null-bucket skip to HEART_RATE only

### DIFF
--- a/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
+++ b/packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt
@@ -3277,11 +3277,19 @@ class HealthPlugin(private var channel: MethodChannel? = null) :
                     val response = healthConnectClient.aggregateGroupByDuration(request)
 
                     for (durationResult in response) {
-                        // The result is null if no data is available in the
-                        // bucket — skip it rather than fabricating a zero
-                        // value (a 0 BPM heart rate is not a real data point).
                         var totalValue = durationResult.result[metricClassType]
-                            ?: continue
+                        if (totalValue == null) {
+                            if (dataType == HEART_RATE) {
+                                // A missing heart-rate bucket means no samples were
+                                // recorded in it — skip it rather than fabricating a
+                                // 0 BPM value, which would not be a real data point.
+                                continue
+                            }
+                            // Every other aggregate type (steps, distance, calories, ...)
+                            // legitimately can be zero for a bucket; report it as such
+                            // rather than dropping the bucket.
+                            totalValue = 0
+                        }
                         if (totalValue is Length) {
                             totalValue = totalValue.inMeters
                         } else if (totalValue is Energy) {


### PR DESCRIPTION
## Summary

PR #18 ("Stream Health Connect reads page-by-page + optional native downsampling (fixes HR OOM)") changed `getAggregateHCData` in `HealthPlugin.kt` so that a missing/empty aggregate bucket is skipped entirely (`?: continue`) instead of falling back to `0`. The stated rationale was heart-rate specific: a 0 BPM reading is not a real data point, so it shouldn't be fabricated for buckets with no HR samples.

That rationale is correct for `HEART_RATE`, but the `continue` was applied unconditionally to every metric type this function handles via `MapToHCAggregateMetric` — `STEPS`, `WEIGHT`, `HEIGHT`, `DISTANCE_DELTA`, `WATER`, the `SLEEP_*` duration types, `ACTIVE_ENERGY_BURNED`, and `TOTAL_CALORIES_BURNED`. For all of those, zero is a legitimate, meaningful value for a bucket (e.g. 0 steps taken, 0 meters traveled, 0 calories burned in an interval with no activity). Skipping the bucket instead of reporting `0` silently drops real data for every non-HR caller.

This PR scopes the skip-on-null behavior to `dataType == HEART_RATE` only, and restores the old zero-fallback for every other aggregate metric type.

- What #18 changed: empty/missing aggregate buckets are skipped (`?: continue`) rather than fabricating `0`.
- Why that's right for heart rate, wrong for everything else: a missing HR bucket means "no samples," and 0 BPM isn't a real physiological reading — but a missing steps/distance/calories/etc. bucket legitimately means "0 occurred in this interval," which is real, reportable data.
- What this PR does: scopes the skip to `HEART_RATE` only; every other metric type gets the old zero-fallback back.

No current caller in `shiftapp_flutter` is affected — it only queries `HEART_RATE` aggregates — but this is a shared plugin fork, and any other/future caller of a non-HR aggregate type would otherwise get silently-missing buckets instead of zeros.

This was caught in review after #18 merged — it's a latent scope issue present in the original PR, not a regression introduced by this change.

Related: #18

## Out of scope (noted, not touched)

Two issues were identified in the surrounding code during this review but are explicitly out of scope for this PR and were not touched:
- A pre-existing bug (predating #18) where the `SleepSessionRecord` branch in `getHCData` reads `response.records` from only the last page of a paginated sleep query instead of accumulating across all pages.
- An unverified assumption that Health Connect records arrive in non-decreasing chronological order across pages, which the `samplingIntervalMillis` downsampling in `getHCData` relies on — not confirmed as a bug, needs real-device validation.

## Diff

Single-file, Kotlin-only change in `packages/health/android/src/main/kotlin/cachet/plugins/health/HealthPlugin.kt`, scoped entirely to the null-bucket-handling block inside `getAggregateHCData`. Does not touch `getHCData`, the page-by-page/`samplingIntervalMillis` downsampling logic, the `HEART_RATE to HeartRateRecord.BPM_AVG` mapping, or the `try/catch` around `getAggregateHCData` — all added by #18 and correct/unrelated.

## Test plan

- [x] Manual review of the diff and surrounding Kotlin control flow (null-check branching, smart-cast to non-null before `is Length` / `is Energy` checks and the `mapOf` construction).
- [ ] Could not run a full Gradle/Kotlin compile in this sandbox — `packages/health/example/android` fails to build with `flutter build apk --debug` due to a pre-existing, unrelated Flutter-Gradle-plugin-loading incompatibility (the example project uses the legacy imperative `apply` style, which the installed Flutter 3.35.4 toolchain rejects). This is a project-config issue independent of this change and was not touched.
- There is no Kotlin unit test suite in this package (`android/src/test` doesn't exist), consistent with the rest of the codebase.
